### PR TITLE
version 1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If `ib-traffic-monitor` cannot not detect any valid InfiniBand device, the progr
 
 ```
 $ ./ib-traffic-monitor -h
-InfiniBand Traffic Monitor - Version 1.3.0
+InfiniBand Traffic Monitor - Version 1.3.1
 usage: ib-traffic-monitor [-r|--refresh <second(s)>]
                           [-e|--ethernet]
                           [-h|--help]
@@ -81,6 +81,8 @@ usage: ib-traffic-monitor [-r|--refresh <second(s)>]
 [05/11/2025] 1.2.0 - optimize program quitting in non-blocking style
 
 [05/16/2025] 1.3.0 - handle SIGINT signal gracefully
+
+[05/20/2025] 1.3.1 - fix typo on port_rcv_constraint_errors metric
 ```
 
 ## Reference

--- a/ib-traffic-monitor.c
+++ b/ib-traffic-monitor.c
@@ -254,7 +254,7 @@ int main(int argc, char *argv[]) {
             mvwprintw(main_window, 2 * ret_get_infiniband_metrics + 14 + i, 28, "%7ld", cur_infiniband_metrics.infiniband[i].port_rcv_errors);
             mvwprintw(main_window, 2 * ret_get_infiniband_metrics + 14 + i, 43, "%8ld", cur_infiniband_metrics.infiniband[i].port_rcv_remote_physical_errors);
             mvwprintw(main_window, 2 * ret_get_infiniband_metrics + 14 + i, 61, "%8ld", cur_infiniband_metrics.infiniband[i].port_rcv_switch_relay_errors);
-            mvwprintw(main_window, 2 * ret_get_infiniband_metrics + 14 + i, 73, "%8ld", cur_infiniband_metrics.infiniband[i].port_rcv_contraint_errors);
+            mvwprintw(main_window, 2 * ret_get_infiniband_metrics + 14 + i, 73, "%8ld", cur_infiniband_metrics.infiniband[i].port_rcv_constraint_errors);
             mvwprintw(main_window, 2 * ret_get_infiniband_metrics + 14 + i, 85, "%8ld", cur_infiniband_metrics.infiniband[i].port_xmit_constraint_errors);
             mvwprintw(main_window, 2 * ret_get_infiniband_metrics + 14 + i, 102, "%8ld", cur_infiniband_metrics.infiniband[i].excessive_buffer_overrun_errors);
             mvwprintw(main_window, 2 * ret_get_infiniband_metrics + 14 + i, 115, "%8ld", cur_infiniband_metrics.infiniband[i].port_xmit_discards);

--- a/infiniband.c
+++ b/infiniband.c
@@ -226,12 +226,12 @@ int get_infiniband_metrics(struct infiniband_metrics *input_infiniband_metrics, 
                 input_infiniband_metrics->infiniband[count].port_xmit_constraint_errors = long_int_value;
             }
 
-            ret_snprintf = snprintf(counter_metric_file_path, PATH_MAX, "%s/port_rcv_contraint_errors", sysfs_device_port_counters);
+            ret_snprintf = snprintf(counter_metric_file_path, PATH_MAX, "%s/port_rcv_constraint_errors", sysfs_device_port_counters);
             ret_read_file = read_file_long_int(counter_metric_file_path, &long_int_value);
             if (ret_snprintf < 0 || ret_read_file < 0) {
-                input_infiniband_metrics->infiniband[count].port_rcv_contraint_errors = 0;
+                input_infiniband_metrics->infiniband[count].port_rcv_constraint_errors = 0;
             } else {
-                input_infiniband_metrics->infiniband[count].port_rcv_contraint_errors = long_int_value;
+                input_infiniband_metrics->infiniband[count].port_rcv_constraint_errors = long_int_value;
             }
 
             ret_snprintf = snprintf(counter_metric_file_path, PATH_MAX, "%s/local_link_integrity_errors", sysfs_device_port_counters);

--- a/infiniband.h
+++ b/infiniband.h
@@ -36,7 +36,7 @@ struct interface {
     long int port_rcv_switch_relay_errors;
     long int link_error_recovery;
     long int port_xmit_constraint_errors;
-    long int port_rcv_contraint_errors;
+    long int port_rcv_constraint_errors;
     long int local_link_integrity_errors;
     long int excessive_buffer_overrun_errors;
     long int port_xmit_data;


### PR DESCRIPTION
this pr is to address a typo issue on the metric name `port_rcv_constraint_errors`.